### PR TITLE
Suggestion for multi-domain-forest environments

### DIFF
--- a/Cleanup-AdminCount.ps1
+++ b/Cleanup-AdminCount.ps1
@@ -39,8 +39,9 @@ Param (
 # 1. Determine AdminSDHolder protected objects
 # 1.1 Get Domain SID and set BuiltIn
 
+    # Root Domain of the Forest
     $RootDomain = (Get-ADForest).RootDomain
-    $RootSID=($RootDomain | Get-ADDomain).DomainSID
+    $RootSID=($RootDomain | Get-ADDomain).DomainSID  # SID of Forest Root Domain
     $DomSID=(Get-ADDomain).DomainSID
     $BuiltIn="S-1-5-32"
 
@@ -79,6 +80,7 @@ Param (
     $DomCon=Get-ADGroup "$DomSID-516"
 
     # SCHEMA_ADMINISTRATORS, S-1-5-21-<root-domain>-518
+    # Talk to Forest Root Domain(-Controller) - especially if executed in a member domain context
     $SchemaAdmins=Get-ADGroup "$RootSID-518" -Server $RootDomain
 
     # ENTERPRISE_ADMINS, S-1-5-21-<root-domain>-519

--- a/Cleanup-AdminCount.ps1
+++ b/Cleanup-AdminCount.ps1
@@ -39,7 +39,8 @@ Param (
 # 1. Determine AdminSDHolder protected objects
 # 1.1 Get Domain SID and set BuiltIn
 
-    $RootSID=((Get-ADForest).Domains | Get-ADDomain).DomainSID
+    $RootDomain = (Get-ADForest).RootDomain
+    $RootSID=($RootDomain | Get-ADDomain).DomainSID
     $DomSID=(Get-ADDomain).DomainSID
     $BuiltIn="S-1-5-32"
 
@@ -78,10 +79,10 @@ Param (
     $DomCon=Get-ADGroup "$DomSID-516"
 
     # SCHEMA_ADMINISTRATORS, S-1-5-21-<root-domain>-518
-    $SchemaAdmins=Get-ADGroup "$RootSID-518"
+    $SchemaAdmins=Get-ADGroup "$RootSID-518" -Server $RootDomain
 
     # ENTERPRISE_ADMINS, S-1-5-21-<root-domain>-519
-    $EntAdmins=Get-ADGroup "$RootSID-519"
+    $EntAdmins=Get-ADGroup "$RootSID-519" -Server $RootDomain
 
     # READONLY_DOMAIN_CONTROLLERS, S-1-5-21-<domain>-521
     $RODC=Get-ADGroup "$DomSID-521"
@@ -89,8 +90,8 @@ Param (
     # KEY_ADMINS, S-1-5-21-<domain>-526
     $KeyAdmins=Get-ADGroup "$DomSID-526"
 
-    # ENTERPRISE_KEY_ADMINS, S-1-5-21-<domain>-527
-    $EntKeyAdmins=Get-ADGroup "$DomSID-527"
+    # ENTERPRISE_KEY_ADMINS, S-1-5-21-<root-domain>-527
+    $EntKeyAdmins=Get-ADGroup "$RootSID-527" -Server $RootDomain
 
 # 1.3 All AdminSDHolder Objects
     $AllAdminSD=


### PR DESCRIPTION
Hi Mark,

thanks for providing this script which we would like to integrate into our AD-Security-Check-Repository. 

By testing it we learned that `$RootSID` did not work as expected - especially when not executed from inside the root domain of a multi-domain-forest. This is why we suggest to add the `-Server $RootDomain` parameter.

In a multi-domain-forest your code for `$RootSID` will return an array of all domain-SIDs in the forest (as opposed to a single SID string like it does with `$DomainSID`). This results in invalid SIDs when string-merging the well-known SIDs for `$EntAdmins` and `$SchemaAdmins`.
In addition there was a little error at merging the SID for `$EntKeyAdmins`: They also need the forest `$RootSID` - not the `$DomainSID` (again: especially when not executed from inside the forest root domain).

Regards

duonierdas